### PR TITLE
rrpush, mzcreate: add -quiet option

### DIFF
--- a/cmd/mzcreate/main.go
+++ b/cmd/mzcreate/main.go
@@ -33,9 +33,10 @@ func main() {
 		"DNS Tools configuration file.")
 	dryRun := flag.Bool("dry-run", true,
 		"Do not take action on Cloud DNS. Just pretend.")
-	noColor := flag.Bool("no-color", false, "Do not colorize output.")
 	gcpSAFile := flag.String("gcp-sa-file", "secret/gcp-sa.json",
 		"Google Cloud Platform Service Account file in JSON format.")
+	noColor := flag.Bool("no-color", false, "Do not colorize output.")
+	quiet := flag.Bool("quiet", false, "Only output changes and errors.")
 	flag.Parse()
 
 	color.NoColor = *noColor
@@ -65,7 +66,9 @@ func main() {
 	for _, mz := range config.ManagedZones {
 		log.SetPrefix(mz.FQDN + " ")
 		if _, ok := gcpManagedZones[mz.FQDN]; ok {
-			log.Printf("OK")
+			if !*quiet {
+				log.Printf("OK")
+			}
 			continue
 		}
 		color.Set(color.FgHiYellow)
@@ -95,8 +98,11 @@ func main() {
 		log.Printf("nameservers: %q", newMZ.NameServers)
 		totalCreated++
 	}
+
 	log.SetPrefix("summary")
-	log.Printf("%v managed zone create", totalCreated)
+	if !*quiet {
+		log.Printf("%v managed zone create", totalCreated)
+	}
 	if !exitOK {
 		log.Fatal("some errors occurred")
 	}

--- a/cmd/rrpush/main.go
+++ b/cmd/rrpush/main.go
@@ -25,6 +25,7 @@ func main() {
 	gcpSAFile := flag.String("gcp-sa-file", "secret/gcp-sa.json",
 		"Google Cloud Platform Service Account file in JSON format.")
 	noColor := flag.Bool("no-color", false, "Do not colorize output.")
+	quiet := flag.Bool("quiet", false, "Only output changes and errors.")
 	flag.Parse()
 
 	// validate flags
@@ -119,7 +120,9 @@ func main() {
 		nDeletions := len(change.Deletions)
 		nAdditions := len(change.Additions)
 		if nDeletions == 0 && nAdditions == 0 {
-			log.Println("nothing to change")
+			if !*quiet {
+				log.Println("nothing to change")
+			}
 			continue
 		} else {
 			if nDeletions > 0 {
@@ -192,15 +195,17 @@ func main() {
 		totalAdditions += nAdditions
 	}
 	log.SetPrefix("summary ")
-	log.Printf("%v records removed, %v records created",
-		totalDeletions, totalAdditions)
-	log.Printf("%v managed zones, %v OK, %v failed, "+
-		"%v missing in local database, %v missing on Cloud DNS",
-		len(config.ManagedZones),
-		len(config.ManagedZones)-totalFailed-totalMissingInDatabase-totalMissingOnCloudDNS,
-		totalFailed,
-		totalMissingInDatabase,
-		totalMissingOnCloudDNS)
+	if !*quiet {
+		log.Printf("%v records removed, %v records created",
+			totalDeletions, totalAdditions)
+		log.Printf("%v managed zones, %v OK, %v failed, "+
+			"%v missing in local database, %v missing on Cloud DNS",
+			len(config.ManagedZones),
+			len(config.ManagedZones)-totalFailed-totalMissingInDatabase-totalMissingOnCloudDNS,
+			totalFailed,
+			totalMissingInDatabase,
+			totalMissingOnCloudDNS)
+	}
 	if !exitOK {
 		log.Fatal("some errors occurred")
 	}


### PR DESCRIPTION
Reduces the output to errors and changes. Unchanged domains won't cause output lines. Improves readability.